### PR TITLE
Allow reading blocks directly from Bitcoin Core `blk*.dat` files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -134,6 +134,7 @@ pub struct Config {
     pub daemon_p2p_addr: SocketAddr,
     pub electrum_rpc_addr: SocketAddr,
     pub monitoring_addr: SocketAddr,
+    pub blocks_dir: PathBuf,
     pub wait_duration: Duration,
     pub jsonrpc_timeout: Duration,
     pub index_batch_size: usize,
@@ -271,6 +272,7 @@ impl Config {
         }
 
         let daemon_dir = &config.daemon_dir;
+        let blocks_dir = daemon_dir.join("blocks");
         let daemon_auth = SensitiveAuth(match (config.auth, config.cookie_file) {
             (None, None) => Auth::CookieFile(daemon_dir.join(".cookie")),
             (None, Some(cookie_file)) => Auth::CookieFile(cookie_file),
@@ -316,6 +318,7 @@ impl Config {
             network: config.network,
             db_path: config.db_dir,
             daemon_dir: config.daemon_dir,
+            blocks_dir,
             daemon_auth,
             daemon_rpc_addr,
             daemon_p2p_addr,

--- a/src/types.rs
+++ b/src/types.rs
@@ -42,6 +42,16 @@ const HASH_PREFIX_LEN: usize = 8;
 type HashPrefix = [u8; HASH_PREFIX_LEN];
 type Height = u32;
 
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Hash, Copy, Clone, PartialOrd, Ord)]
+pub(crate) struct FilePosition {
+    #[serde(rename = "file")]
+    pub file_id: u16, // blk*.dat file index (<3k as of 2022/01)
+    #[serde(rename = "data")]
+    pub offset: u32, // offset within a single blk*.dat file (~128MB as 2022/01)
+}
+
+impl_consensus_encoding!(FilePosition, file_id, offset);
+
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub(crate) struct HashPrefixRow {
     prefix: [u8; HASH_PREFIX_LEN],


### PR DESCRIPTION
Requires `getblocklocations` RPC.